### PR TITLE
Add DB optimization on shutdown

### DIFF
--- a/DB_SETUP_MARIADB.md
+++ b/DB_SETUP_MARIADB.md
@@ -96,4 +96,14 @@ Do reduce I/O times and though causing significant speedup while syncing, one ma
 SET GLOBAL innodb_flush_log_at_trx_commit = 0;
 ```
 
-See more details [here](https://mariadb.com/docs/server/ref/mdb/system-variables/innodb_flush_log_at_trx_commit/). 
+See more details [here](https://mariadb.com/docs/server/ref/mdb/system-variables/innodb_flush_log_at_trx_commit/).
+
+## Optimization
+
+To reduce disk usage the node can optimize all MariaDB tables on shutdown. Enable this behaviour in `conf/node.properties`:
+
+```properties
+DB.Optimize = on
+```
+
+With this setting the node issues `OPTIMIZE TABLE` for every table before closing. The process may take a while depending on database size.

--- a/DB_SETUP_POSTGRESQL.md
+++ b/DB_SETUP_POSTGRESQL.md
@@ -53,6 +53,16 @@ DB.Username=signumnode
 DB.Password=s1gn00m_n0d3
 ```
 
+## Optimization
+
+When the `DB.Optimize` property is enabled the node performs `VACUUM ANALYZE` on shutdown to reclaim disk space and update statistics. Configure this in `conf/node.properties`:
+
+```properties
+DB.Optimize = on
+```
+
+The optimization step can take several minutes depending on database size.
+
 ## For Test Net
 
 > Testnet is usually only for slightly advanced users. The testnet allows you "play" around without having to buy/get real SIGNA. 

--- a/src/brs/db/sql/dialects/DatabaseInstanceMariaDb.java
+++ b/src/brs/db/sql/dialects/DatabaseInstanceMariaDb.java
@@ -33,7 +33,9 @@ public class DatabaseInstanceMariaDb extends DatabaseInstanceBaseImpl {
   }
 
   @Override
-  protected void onShutdownImpl() {}
+  protected void onShutdownImpl() {
+    optimizeAllTables();
+  }
 
   @Override
   public SQLDialect getDialect() {

--- a/src/brs/db/sql/dialects/DatabaseInstancePostgres.java
+++ b/src/brs/db/sql/dialects/DatabaseInstancePostgres.java
@@ -20,7 +20,12 @@ public class DatabaseInstancePostgres extends DatabaseInstanceBaseImpl {
   }
 
   @Override
-  protected void onShutdownImpl() {}
+  protected void onShutdownImpl() {
+    if (propertyService.getBoolean(Props.DB_OPTIMIZE)) {
+      logger.info("Running VACUUM ANALYZE on PostgreSQL...");
+      executeSQL("VACUUM (ANALYZE)");
+    }
+  }
 
   @Override
   public SQLDialect getDialect() {


### PR DESCRIPTION
## Summary
- add utility to optimize tables in DatabaseInstanceBaseImpl
- run full optimization on shutdown for MariaDB and PostgreSQL
- document DB.Optimize usage in MariaDB and Postgres setup guides

## Testing
- `./gradlew test` *(fails: No route to host)*