### PR TITLE
Fix missing imports in JSONData and Postgres dialect

### DIFF
--- a/src/brs/db/sql/dialects/DatabaseInstancePostgres.java
+++ b/src/brs/db/sql/dialects/DatabaseInstancePostgres.java
@@ -1,6 +1,7 @@
 package brs.db.sql.dialects;
 
 import brs.props.PropertyService;
+import brs.props.Props;
 import com.zaxxer.hikari.HikariConfig;
 import org.jooq.SQLDialect;
 import org.slf4j.Logger;

--- a/src/brs/web/api/http/common/JSONData.java
+++ b/src/brs/web/api/http/common/JSONData.java
@@ -15,6 +15,7 @@ import brs.util.JSON;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
 import static brs.web.api.http.common.ResultFields.*;
 


### PR DESCRIPTION
## Summary
- import `JsonPrimitive` for JSON utility
- import `Props` for Postgres database dialect

## Testing
- `./gradlew test --offline` *(fails: No route to host)*