### PR TITLE
Fix download cache lock

### DIFF
--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -1177,6 +1177,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
         stores.rollbackTransaction();
         blockchain.setLastBlock(previousLastBlock);
         downloadCache.resetCache();
+        downloadCache.unlockCache();
         atProcessorCache.reset();
         throw e;
       } finally {
@@ -1605,6 +1606,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
             Convert.toUnsignedLong(block.getGeneratorId()), block.getStringId(), block.getHeight());
         }
         downloadCache.resetCache();
+        downloadCache.unlockCache();
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (TransactionNotAcceptedException e) {


### PR DESCRIPTION
## Summary
- unlock `DownloadCache` after reset to avoid prolonged lock state

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683a23ce57788323ab92e2bddc080632