### PR TITLE
Fix locked download cache after processing forks

### DIFF
--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -662,6 +662,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
             logger.info("Forkprocessing complete.");
             downloadCache.resetForkBlocks();
             downloadCache.resetCache(); // Reset and set cached vars to chaindata.
+            downloadCache.unlockCache();
           }
         }
       }


### PR DESCRIPTION
## Summary
- unlock the download cache after processing a fork to allow new blocks

## Testing
- `./gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683cb9613e2483239c2109b8bd029fcf